### PR TITLE
Use whitespace keepalives instead of presence stanzas

### DIFF
--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -120,10 +120,10 @@ function SimpleXMPP() {
             conn.send(new xmpp.Element('presence'));
             events.emit('online');
             $.start();
-            //make the connection live
+            // Use whitespace keepalives to keep the connection up
             setInterval(function() {
-               conn.send(new xmpp.Element('presence'));
-            }, 1000 * 10)
+               conn.send(' ');
+            }, 1000 * 60)
         });
 
         conn.on('stanza', function(stanza) {


### PR DESCRIPTION
Sending <presence> stanzas too frequently may cause issues with servers rate limiting the user (see issue #15). This switches to using whitespace for keepalives instead. 

From XMPP specs:

   One common method for checking the TCP connection is to send a space
   character (U+0020) between XML stanzas, which is allowed for XML
   streams as described under Section 11.7; the sending of such a space
   character is properly called a "whitespace keepalive" (the term
   "whitespace ping" is often used, despite the fact that it is not a
   ping since no "pong" is possible).
