### PR TITLE
Ensure capabilities response contains <query> node before trying to use it

### DIFF
--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -328,13 +328,13 @@ function SimpleXMPP() {
                 // Response to capabilities request?
                 if (stanza.attrs.id === 'disco1') {
                     var query = stanza.getChild('query', 'http://jabber.org/protocol/disco#info');
-					
-					// Ignore it if there's no <query> element - Not much we can do in this case!
-					if (!query) {
-						return;
-					}
-					
-					var node = query.attrs.node,
+                    
+                    // Ignore it if there's no <query> element - Not much we can do in this case!
+                    if (!query) {
+                        return;
+                    }
+                    
+                    var node = query.attrs.node,
                         identity = query.getChild('identity'),
                         features = query.getChildren('feature');
 


### PR DESCRIPTION
This fixes issue #29.
