### PR TITLE
Added conference parameter to groupbuddy event.

### DIFF
--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -335,7 +335,7 @@ function SimpleXMPP() {
                           //specifying roster changes
                           if(joinedRooms[id]){
                             var groupBuddy = from.split('/')[1];
-                            events.emit('groupBuddy', groupBuddy, state, statusText);
+                            events.emit('groupbuddy', id, groupBuddy, state, statusText);
                           } else {
                             events.emit('buddy', id, state, statusText);
                           }

--- a/readme.md
+++ b/readme.md
@@ -118,9 +118,10 @@ xmpp.on('buddy', function(jid, state, statusText) {
 ```
 #### Group Buddy
 Event emitted when state of the buddy on group chat you recently joined changes
+
 ```javascript
-xmpp.on('groupBuddy', function(from, state, statusText) {
-	console.log('%s is in %s state - %s', from, state, statusText);
+xmpp.on('groupbuddy', function(conference, from, state, statusText) {
+	console.log('%s: %s is in %s state - %s',conference, from, state, statusText);
 });
 ```
 #### Buddy capabilities


### PR DESCRIPTION
I thought it is going to be usefull to actually know which conference you got presence stanza from. So I have added that parameter into the event handler. I also changed event name to lowercase  to better match project's conventions. Updated docs accordingly as well.
