### PR TITLE
xmpp ping response added.

### DIFF
--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -376,7 +376,7 @@ function SimpleXMPP() {
 				var ping = stanza.getChild('ping', 'urn:xmpp:ping');
 					if(ping){
 					  var pong = new xmpp.Element('iq', { id: stanza.attrs.id, to: stanza.attrs.from, type: 'result' });
-					  xmpp.conn.send(pong);
+					  conn.send(pong);
 					}
 				}
                 // Response to capabilities request?

--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -371,9 +371,16 @@ function SimpleXMPP() {
                   }
                 }
             } else if (stanza.is('iq')) {
-
+				if(stanza.children[0].name == 'query')
+				{
+				var ping = stanza.getChild('ping', 'urn:xmpp:ping');
+					if(ping){
+					  var pong = new xmpp.Element('iq', { id: stanza.attrs.id, to: stanza.attrs.from, type: 'result' });
+					  xmpp.conn.send(pong);
+					}
+				}
                 // Response to capabilities request?
-                if (stanza.attrs.id === 'disco1') {
+               else if (stanza.attrs.id === 'disco1') {
                     var query = stanza.getChild('query', 'http://jabber.org/protocol/disco#info');
 
                     // Ignore it if there's no <query> element - Not much we can do in this case!


### PR DESCRIPTION
Xmpp server, like openFire, send ping request to every client after a defined interval. Ever buddy (client) has to respond to that ping response to tell the xmpp server that the client is alive. other wise server will close the connection to that client.
I have added the code in the simple Xmpp file to respond to that ping. (ping - pong)