### PR TITLE
Fixed error in which it was trying to access a non existing method

### DIFF
--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -83,7 +83,7 @@ function SimpleXMPP() {
             if(!joinedRooms[room]){
                 joinedRooms[room] = true;
             }
-            var stanza =  new xmpp.Element('presence', { to: to }).
+            var stanza =  new xmpp.Stanza.Element('presence', { to: to }).
             c('x', { xmlns: 'http://jabber.org/protocol/muc' });
             conn.send(stanza);
         });
@@ -247,15 +247,15 @@ function SimpleXMPP() {
     // Options:
     //   * skipPresence - don't send initial empty <presence/> when connecting
     //
-    
-    
+
+
 	this.disconnect = function() {
 		$.ready(function() {
 			var stanza = new xmpp.Stanza('presence', { type: 'unavailable' });
 			stanza.c('status').t('Logged out');
 			conn.send(stanza);
 		});
-			
+
 		var ref = this.conn.connection;
 		if (ref.socket.writable) {
 			if (ref.streamOpened) {
@@ -266,8 +266,8 @@ function SimpleXMPP() {
 			}
 		}
 	};
-	
-	
+
+
     this.connect = function(params) {
 
         config = params;


### PR DESCRIPTION
It threw an undefined method error because it could not find the Element function.