### PR TITLE
FIX: the "chat" event should return the full "stanza.attrs.from" string

### DIFF
--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -332,8 +332,7 @@ function SimpleXMPP() {
                     if(body) {
                         var message = body.getText();
                         var from = stanza.attrs.from;
-                        var id = from.split('/')[0];
-                        events.emit('chat', id, message);
+                        events.emit('chat', from, message);
                     }
 
                     var chatstate = stanza.getChildByAttr('xmlns', NS_CHATSTATES);


### PR DESCRIPTION
The "from" parameter returned by the "chat" event contains only the room name, not the actual sender. This is not what the README says, and is not consistent with other events, e.g. groupchat.
This changed during commit 45547133c7d6a19e6532feb6eb9d2b70e0d2e715, and looks like a debug code left by mistake.

Possibly answers #82.