### PR TITLE
The "chat" event should return the complete "stanza.attrs.from"

### DIFF
--- a/lib/simple-xmpp.js
+++ b/lib/simple-xmpp.js
@@ -27,7 +27,6 @@
 var xmpp = require('node-xmpp-client');
 var Stanza = xmpp.Stanza; // http://node-xmpp.org/doc/ltx.html
 var EventEmitter = require('events').EventEmitter;
-var util = require('util');
 var qbox = require('qbox');
 
 var STATUS = {
@@ -331,9 +330,7 @@ function SimpleXMPP() {
                     var body = stanza.getChild('body');
                     if(body) {
                         var message = body.getText();
-                        var from = stanza.attrs.from;
-                        var id = from.split('/')[0];
-                        events.emit('chat', id, message);
+                        events.emit('chat', stanza.attrs.from, message);
                     }
 
                     var chatstate = stanza.getChildByAttr('xmlns', NS_CHATSTATES);

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ xmpp.on('close', function() {
 ```
 
 #### Chat
-Event emitted when somebody sends a chat message to you
+Event emitted when somebody sends a chat message to you (either a direct message or a private pessage from a MUC)
 
 ```javascript
 xmpp.on('chat', function(from, message) {

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ xmpp.on('close', function() {
 ```
 
 #### Chat
-Event emitted when somebody sends a chat message to you (either a direct message or a private pessage from a MUC)
+Event emitted when somebody sends a chat message to you (either a direct message or a private message from a MUC)
 
 ```javascript
 xmpp.on('chat', function(from, message) {


### PR DESCRIPTION
After gaining some insight on XMPP, I am reiterating an old, broken pull request  (#86)

The "from" parameter returned from the `chat` event drops the "resource" part of the JID. This contradicts the README, and the inconsistency with the `groupchat` event is unexpected (although somewhat understandable).
This was changed during bac143351a75c98ee7fb888bbbb2da3d3adadaa2, probably overlooking cases when the chat is a [private message from a MUC](https://xmpp.org/extensions/xep-0045.html#privatemessage) (then the first part before the `/` is just the room's JID).

Fixes #82.
